### PR TITLE
Obtain User's Email via Identity Toolkit

### DIFF
--- a/auth/routes.js
+++ b/auth/routes.js
@@ -1,4 +1,5 @@
 var google = require('googleapis')
+var identitytoolkit = google.identitytoolkit('v3')
 var words = require('random-words')
 var scrambler = require('./scrambler')
 var OAuth2 = google.auth.OAuth2
@@ -17,9 +18,12 @@ function generate_auth() {
 
 var server_auth = generate_auth()
 
-var scope = ['https://www.googleapis.com/auth/calendar']
+var scopes = [
+  'https://www.googleapis.com/auth/calendar',
+  'profile'
+]
 var login_link = server_auth.generateAuthUrl({
-  scope: scope,
+  scope: scopes.join(' '),
   redirect_uri: credentials.redirect_uri
 })
 
@@ -56,9 +60,18 @@ function authorize (req, res) {
       oauth2Clients[cookie] = generate_auth()
       res.cookie('auth', scrambler.encrypt(cookie))
       oauth2Clients[cookie].setCredentials(token)
+
+      identitytoolkit.relyingparty.getAccountInfo({
+        auth: oauth2Clients[cookie]
+      }, (err, response) => {
+        if(err) {
+          console.error(err);
+        }
+        console.log(response)
+        res.redirect('/')
+      })
     }
 
-    res.redirect('/')
   })
 }
 

--- a/config/config.js
+++ b/config/config.js
@@ -11,5 +11,6 @@ if(env == 'development') {
     auth_provider_x509_cert_url: process.env.auth_provider_x509_cert_url,
     client_secret: process.env.client_secret,
     redirect_uri: process.env.redirect_uri,
+    api_key: process.env.api_key
   }
 }

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -62,6 +62,7 @@
 <body>
 
     <nav class="navbar navbar-light bg-faded">
+        <a class="navbar-brand" href="#"><%= email %></a>
         <span class="navbar-text float-xs-right text-muted">
             <a class="btn btn-primary" href='/logout' role="button">Logout</a>
         </span>
@@ -81,7 +82,7 @@
         </tbody>
     </table>
 
-    <iframe src="https://calendar.google.com/calendar/embed?src=skmehta@andrew.cmu.edu&ctz=America/New_York" style="border: 0; width: 100%; height: 600px" frameborder="0" scrolling="no"></iframe>
+    <iframe src="https://calendar.google.com/calendar/embed?src=<%= email %><&ctz=America/New_York" style="border: 0; width: 100%; height: 600px" frameborder="0" scrolling="no"></iframe>
 </body>
 
 </html>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -81,7 +81,7 @@
         </tbody>
     </table>
 
-    <iframe src="https://calendar.google.com/calendar/embed?src=skmehta@andrew.cmu.edu&ctz=America/New_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    <iframe src="https://calendar.google.com/calendar/embed?src=skmehta@andrew.cmu.edu&ctz=America/New_York" style="border: 0; width: 100%; height: 600px" frameborder="0" scrolling="no"></iframe>
 </body>
 
 </html>


### PR DESCRIPTION
This will allow us to just use Google's native Calender UI, rather than reinvent the wheel.

Right now the view is just hardcoding in the following HTML, but this will change to parameterize based on whoever is logged in:

``` HTML
<iframe
src="https://calendar.google.com/calendar/embedsrc=skmehta@andrew.cmu.edu&ctz=America/New_York" 
style="border: 0" 
width="800" 
height="600" 
frameborder="0" 
scrolling="no"></iframe>
```

The user's email is available as `<%= email %>` in `index.ejs`
