### PR TITLE
Pull all calendar events during allocation process

### DIFF
--- a/app/allocate.js
+++ b/app/allocate.js
@@ -39,14 +39,14 @@ function divvy(project, oauth2Client, callback) {
             event.start += FIFTEEN_MINUTES
             event.end += FIFTEEN_MINUTES
             attempts += 1
-            if (attempts > 96) { callback([]) } // could not allocate before next day
+            if (attempts > 96) { callback('could not allocate') } // could not allocate before next day
           } else {
             doesNotOverlap = false
           }
           finishedWithLoop()
         }) // async.reduce
       }, () => { allocatedEvents.push(event); done() }) // async.whilst
-    }, () => { callback(allocatedEvents) }) // async.each
+    }, () => { callback(null, allocatedEvents) }) // async.each
   }) // events.getEvents
 }
 
@@ -75,19 +75,24 @@ function postProject(oauth2Client, projectData, res) {
       console.log(errors)
       res.status(400).send(errors)
     } else {
-      divvy(project, oauth2Client, (allocatedEvents) => {
-        async.each(allocatedEvents, (event, done) => {
-          events.persistEvent(oauth2Client, event, (err) => {
-            done(err)
+      divvy(project, oauth2Client, (err, allocatedEvents) => {
+        if(err) {
+          console.log(err)
+          res.sendStatus(500)
+        } else {
+          async.each(allocatedEvents, (event, done) => {
+            events.persistEvent(oauth2Client, event, (error) => {
+              done(error)
+            })
+          }, (err) => {
+            if (err) {
+              console.log(err.stack)
+              res.sendStatus(500)
+            } else {
+              res.sendStatus(201)
+            }
           })
-        }, (err) => {
-          if (err) {
-            console.log(err.stack)
-            res.sendStatus(500)
-          } else {
-            res.sendStatus(201)
-          }
-        })
+        }
       })
     }
   } catch (err) {

--- a/app/allocate.js
+++ b/app/allocate.js
@@ -63,8 +63,9 @@ function postProject(oauth2Client, projectData, res) {
   try {
     // want to start project at the next given preferred time
 
+    const dummy = new Date()
     project = {
-      start: new Date(new Date().getTime() + 5000), // start 5 seconds from now
+      start: new Date(dummy.getTime()),
       end: new Date(projectData.dueDate),
       summary: projectData.eventTitle,
       hours: projectData.estimatedHours

--- a/app/allocate.js
+++ b/app/allocate.js
@@ -76,9 +76,9 @@ function postProject(oauth2Client, projectData, res) {
       console.log(errors)
       res.status(400).send(errors)
     } else {
-      divvy(project, oauth2Client, (err, allocatedEvents) => {
-        if(err) {
-          console.log(err)
+      divvy(project, oauth2Client, (divvyErr, allocatedEvents) => {
+        if (divvyErr) {
+          console.log(divvyErr)
           res.sendStatus(500)
         } else {
           async.each(allocatedEvents, (event, done) => {

--- a/app/events.js
+++ b/app/events.js
@@ -87,11 +87,14 @@ function formatDate (date) {
   * @param {function} callback function to be called with results of API call
   */
 function getEvents (project, oauth2Client, callback) {
+  // pull events from the full most recent day so we don't allocate during
+  // currently ongoing events
+  const tempStart = new Date(project.start.getTime() - ONE_DAY)
   calendar.events.list({
     auth: oauth2Client,
     calendarId: 'primary',
     timeMax: formatDate(project.end),
-    timeMin: formatDate(project.start),
+    timeMin: formatDate(tempStart),
     fields: "items(end/dateTime,start/dateTime,summary)",
     singleEvents: true
   }, (err, response) => {

--- a/public/home.js
+++ b/public/home.js
@@ -64,6 +64,7 @@ function submitTaskForm() {
     data: data,
     success: () => {
       postStatus.className = 'fa fa-check'
+      setTimeout(() => { location.reload() }, 1000)
     },
     error: (err) => {
       console.error(err)

--- a/public/home.js
+++ b/public/home.js
@@ -88,8 +88,8 @@ function toggleFormExtras() {
 $(function() {
   fetchUserDefaultSettings()
 
-  // format due date default to tomorrow
-  var tomorrow = new Date(new Date().getTime() + (24 * 60 * 60 * 1000));
+  // format due date default to three days from now
+  var tomorrow = new Date(new Date().getTime() + (3 * 24 * 60 * 60 * 1000));
   var tomday = tomorrow.getDate();
   var tommonth = tomorrow.getMonth() + 1;
   var tomyear = tomorrow.getFullYear();

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -63,16 +63,6 @@
                 </div>
               </div>
               <div class="form-group col-sm-8 offset-sm-2">
-                <label for="calendar" class="col-xs-4 col-form-label">Calendar:</label>
-                <div class="col-xs-8">
-                  <select class="form-control" name="calendar" id = "calendar">
-                    <% for(var i=0; i<calendars.length; i++) {%>
-                      <option value="<%= calendars[i].id %>"><%= calendars[i].summary %></option>
-                    <% } %>
-                  </select>
-                </div>
-              </div>
-              <div class="form-group col-sm-8 offset-sm-2">
                 <label for="sleepTime" class="col-xs-4 col-form-label">Sleep Time:</label>
                 <div class="col-xs-8">
                   <input class="form-control" type="time" value="22:30:00" id = "sleepTime" name="sleepTime">


### PR DESCRIPTION
Previously, it would not allocate properly if you were currently in the middle of an event. This PR simply changes the range in which we pull events. The crux of the PR is here:

```diff
+  // pull events from the full most recent day so we don't allocate during
+  // currently ongoing events
+  const tempStart = new Date(project.start.getTime() - ONE_DAY)
   calendar.events.list({
     auth: oauth2Client,
     calendarId: 'primary',
     timeMax: formatDate(project.end),
-    timeMin: formatDate(project.start),
+    timeMin: formatDate(tempStart),
```

The rest is just comments and better error handling.